### PR TITLE
Change migration timestamps

### DIFF
--- a/migrations/2016_05_02_193213_create_gateway_transactions_table.php
+++ b/migrations/2016_05_02_193213_create_gateway_transactions_table.php
@@ -43,7 +43,7 @@ class CreateGatewayTransactionsTable extends Migration
 			])->default(Enum::TRANSACTION_INIT);
 			$table->string('ip', 20)->nullable();
 			$table->timestamp('payment_date')->nullable();
-			$table->timestamps();
+			$table->nullableTimestamps();
 			$table->softDeletes();
 		});
 	}


### PR DESCRIPTION
default value for created_at and updated_at should be null or in its special format. By default it uses 0 as default value and it causes an error :)