### PR TITLE
make ref_id nullable

### DIFF
--- a/migrations/2016_05_02_193213_create_gateway_transactions_table.php
+++ b/migrations/2016_05_02_193213_create_gateway_transactions_table.php
@@ -33,7 +33,7 @@ class CreateGatewayTransactionsTable extends Migration
 				Enum::ZARINPAL,
 			]);
 			$table->decimal('price', 15, 2);
-			$table->string('ref_id', 100);
+			$table->string('ref_id', 100)->nullable();
 			$table->string('tracking_code', 50)->nullable();
 			$table->string('card_number', 50)->nullable();
 			$table->enum('status', [


### PR DESCRIPTION
Hi,

According to the error and PoolPort source and the mentioned function, ref_id should be nullable :

Error:

```
`SQLSTATE[HY000]: General error: 1364 Field 'ref_id' doesn't have a default value (SQL: insert into `gateway_transactions` (`id`, `port`, `price`, `status`, `ip`, `created_at`, `updated_at`) values (1477224769, MELLAT, 1000, INIT, 192.168.10.1, 2016-10-23 15:42:50, 2016-10-23 15:42:50))`
```

Insert function :

```
` protected function newTransaction()
{
    $uid = $this->getTimeId();
    $this->transactionId = $this->getTable()->insert([
        'id' => $uid,
        'port' => $this->getPortName(),
        'price' => $this->amount,
        'status' => Enum::TRANSACTION_INIT,
        'ip' => Request::getClientIp(),
        'created_at' => Carbon::now(),
        'updated_at' => Carbon::now(),
    ]) ? $uid : null;

    return $this->transactionId;
}`
```

poolport source includes this line : 

```
``ref_id` varchar(255) COLLATE utf8_persian_ci DEFAULT NULL,`
```
