### PR TITLE
Setting encoding to utf-8 in zarinpal.php

### DIFF
--- a/src/Zarinpal/Zarinpal.php
+++ b/src/Zarinpal/Zarinpal.php
@@ -179,7 +179,7 @@ class Zarinpal extends PortAbstract implements PortInterface
 		);
 
 		try {
-			$soap = new SoapClient($this->serverUrl);
+			$soap = new SoapClient($this->serverUrl, ['encoding' => 'UTF-8']);
 			$response = $soap->PaymentRequest($fields);
 
 		} catch (\SoapFault $e) {
@@ -236,7 +236,7 @@ class Zarinpal extends PortAbstract implements PortInterface
 		);
 
 		try {
-			$soap = new SoapClient($this->serverUrl);
+			$soap = new SoapClient($this->serverUrl, ['encoding' => 'UTF-8']);
 			$response = $soap->PaymentVerification($fields);
 
 		} catch (\SoapFault $e) {


### PR DESCRIPTION
ignoring utf8 causes soap error like :
SOAP-ERROR: Parsing WSDL: Couldn't load from ...