### PR TITLE
fix Saman cardNumber & RefId Saving

### DIFF
--- a/src/Saman/Saman.php
+++ b/src/Saman/Saman.php
@@ -121,9 +121,9 @@ class Saman extends PortAbstract implements PortInterface
      */
     protected function userPayment()
     {
-        $this->refId = Input::get('RefNum');
-        $this->trackingCode = Input::get('‫‪TRACENO‬‬');
-        $this->cardNumber = Input::get('‫‪SecurePan‬‬');
+        $this->refId = Input::get('ResNum');
+        $this->trackingCode = Input::get('TRACENO');
+        $this->cardNumber = Input::get('SecurePan');
         $payRequestRes = Input::get('State');
         $payRequestResCode = Input::get('StateCode');
 


### PR DESCRIPTION
در آخرین نسخه به دلیل وجود کاراکتر اضافی در نام پارامترها شماره کارت و شناسه مرجع ثبت نمی شد.