### PR TITLE
remove unused imports & add import Schema facade in migrations

### DIFF
--- a/migrations/2016_05_02_193213_create_gateway_transactions_table.php
+++ b/migrations/2016_05_02_193213_create_gateway_transactions_table.php
@@ -2,8 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use Larabookir\Gateway\PortAbstract;
-use Larabookir\Gateway\GatewayResolver;
+use Illuminate\Support\Facades\Schema;
 use Larabookir\Gateway\Enum;
 
 class CreateGatewayTransactionsTable extends Migration

--- a/migrations/2016_05_02_193229_create_gateway_status_log_table.php
+++ b/migrations/2016_05_02_193229_create_gateway_status_log_table.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-
+use Illuminate\Support\Facades\Schema;
 class CreateGatewayStatusLogTable extends Migration
 {
 

--- a/migrations/2017_04_05_103357_alter_id_in_transactions_table.php
+++ b/migrations/2017_04_05_103357_alter_id_in_transactions_table.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class AlterIdInTransactionsTable extends Migration


### PR DESCRIPTION
VS code would complain if you don't import your facades.
`Schema` facade added and useless imports removed from migration files. 